### PR TITLE
RequireOrder

### DIFF
--- a/goopt.go
+++ b/goopt.go
@@ -42,6 +42,10 @@ var Version = ""
 // application name) (used in the default manpage())
 var Suite = ""
 
+// Redefine this to force flags to come before all options or be
+// treated as if they were options
+var RequireOrder = false
+
 // Variables for expansion using Expand(), which is automatically
 // called on help text for flags
 var Vars = make(map[string]string)
@@ -469,6 +473,10 @@ func Parse(extraopts func() []string) {
 				failnoting("Bad flag:", errors.New(a))
 			}
 		} else {
+			if RequireOrder {
+				Args = cat(Args, os.Args[i:])
+				break
+			}
 			append(&Args, a)
 		}
 	}


### PR DESCRIPTION
I've added a RequireOrder option that mimics the "require_order" configuration flag for Getopt::Long in Perl (http://perldoc.perl.org/Getopt/Long.html#require_order), which makes the module able to be more "POSIXLY_CORRECT", and opens up the possibility of doing partial processing (ala git itself having global git flags and then more local subcommand flags later on).

I think a very nice compliment to this option would be a way to specify an arbitrary slice to parse in place of os.Args so that this really could be run multiple times for subcommands and the like, although then we run into scoping issues of not wanting previously defined flags to be processed on the second run (which is why a commit for that change isn't included here also).  A solution I would propose for that (and would love some dialog about) would be a "GoOpt" struct/object that contains all the options parsing but includes a backwards-compatible interface that just uses a shared object.  If you like the idea, I'd really enjoy implementing such a thing and sending another pull request when it is complete.
