### PR TITLE
Remove -v as a synonym for --version.

### DIFF
--- a/goopt.go
+++ b/goopt.go
@@ -411,7 +411,7 @@ func Parse(extraopts func() []string) bool {
 			os.Exit(0)
 			return nil
 		}})
-	addOpt(opt{[]string{"--version", "-v"}, "", "Show version", false, nil,
+	addOpt(opt{[]string{"--version"}, "", "Show version", false, nil,
 		func(string) error {
 			fmt.Println(Version)
 			os.Exit(0)


### PR DESCRIPTION
Note that -v is commonly used for --verbose, and should
not be grabbed by the goopt library, especially this late
in its release cycle.

(I'm sure mine wasn't the only program broken by this change.)