### PR TITLE
getopt_long accepts "-" as an argument value. This change makes goopt…

### DIFF
--- a/goopt.go
+++ b/goopt.go
@@ -467,7 +467,8 @@ func Parse(extraopts func() []string) bool {
 								//	j+1 == len(a)-1 &&
 								len(os.Args) > i+skip+1 &&
 								len(os.Args[i+skip+1]) >= 1 &&
-								os.Args[i+skip+1][0] != '-':
+								(os.Args[i+skip+1] == "-" ||
+									os.Args[i+skip+1][0] != '-'):
 								// this last one prevents options from taking options as arguments...
 								failnoting("Error in flag -"+string(c)+":",
 									o.process(os.Args[i+skip+1]))
@@ -508,7 +509,7 @@ func Parse(extraopts func() []string) bool {
 							}
 							failnoting("Error in flag "+a+":",
 								o.process(a[x+1:len(a)]))
-						} else if o.allowsArg != nil && len(os.Args) > i+1 && len(os.Args[i+1]) >= 1 && os.Args[i+1][0] != '-' {
+						} else if o.allowsArg != nil && len(os.Args) > i+1 && len(os.Args[i+1]) >= 1 && (os.Args[i+1] == "-" || os.Args[i+1][0] != '-') {
 							// last check sees if the next arg looks like a flag
 							failnoting("Error in flag "+n+":",
 								o.process(os.Args[i+1]))


### PR DESCRIPTION
… behave the same way.

Evidence:

```c
#include <stdio.h>
#include <stdlib.h>
#include <getopt.h>

int
main (int argc, char **argv)
{
  int c;

  while (1)
    {
      static struct option long_options[] =
        {
          {"file",    required_argument, 0, 'f'},
          {0, 0, 0, 0}
        };
      /* getopt_long stores the option index here. */
      int option_index = 0;

      c = getopt_long (argc, argv, "f:",
                       long_options, &option_index);

      /* Detect the end of the options. */
      if (c == -1)
        break;

      switch (c)
        {
        case 0:
          printf ("option %s", long_options[option_index].name);
          if (optarg)
            printf (" with arg %s", optarg);
          printf ("\n");
          break;

        case 'f':
          printf ("option -f with value `%s'\n", optarg);
          break;

        case '?':
          /* getopt_long already printed an error message. */
          break;

        default:
          abort ();
        }
    }

  /* Print any remaining command line arguments (not options). */
  if (optind < argc)
    {
      printf ("non-option ARGV-elements: ");
      while (optind < argc)
        printf ("%s ", argv[optind++]);
      putchar ('\n');
    }

  exit (0);
}
```

```sh
10009» cc -o main ./main.c
10010» ./main -f -
option -f with value `-'
```

`goopt` behaves differently:

```go
package main

import "github.com/droundy/goopt"
import "fmt"

func main() {
	file := goopt.String([]string{"--file", "-f"}, "", "file name")
	goopt.Parse(nil)
	fmt.Printf("option -f with value `%s'\n", file)
}
```

```sh
10012» go run ./main.go -f -
Flag -f requires argument!
exit status 1
```

This patch allows `goopt` to behave like `getopt_long`:

```
10006(master)⚡ » go run ./test/main.go -f -
option -f with value `-'
```